### PR TITLE
reduce gitignore to project necessities

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,8 @@
 # Logs
-logs
-*.log
 npm-debug.log*
-yarn-debug.log*
-yarn-error.log*
-pnpm-debug.log*
-lerna-debug.log*
 
-node_modules
-dist
-dist-ssr
-*.local
+# Package dependencies
+node_modules/
 
-# Editor directories and files
-.vscode/*
-!.vscode/extensions.json
-.idea
-.DS_Store
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-*.sw?
+# Build artifacts
+dist/


### PR DESCRIPTION
My opinion is that project gitignores should only include files that are directly related to the project agnostic of developer environment.

For this project, the only generated files I notice following the actions listed in the readme are `node_modules` and `dist`, so I leave those. Since the project is using `npm`, I remove the ignores for log files from other package managing software like `yarn`.

I've explained this specific thing to probably 5 devs in the last decade so to save myself time for the next time, I wrote up my thoughts on this and published them here for reference: [Global gitignore](https://www.notion.so/spaceofmike/Global-gitignore-001d77075d874986b3a20516026babca) (lmk if it's not accessible to you)